### PR TITLE
Mgrs in polar region

### DIFF
--- a/src/usng.ts
+++ b/src/usng.ts
@@ -1386,19 +1386,40 @@ extend(Converter.prototype, {
   //    in MGRS notation.  but the numbers are the same.
   LLtoMGRS: function(lat, lon, precision) {
     if (this.isInUPSSpace(lat)) {
-      var ups_obj = {...this.LLtoUPS(lat, lon), northpole: lat > 0 ? true : false };
-      console.log(ups_obj);
-      throw new Error("Not yet Implemented");
+      var ups_obj = this.LLtoUPS(lat, lon);
+      var mgrs_str = ups_obj.northPole ? (ups_obj.easting < 2e6 ? "Y" : "Z") : (ups_obj.easting < 2e6 ? "A" : "B");
+      if (precision <= 0) {
+        return mgrs_str;
+      }
+      const UPS_N_east_letters = "RSTUXYZABCFGHJ"; // starting from 1300000mE
+      const UPS_N_north_letters = "ABCDEFGHJKLMNP"; // starting from 1300000mN
+      const UPS_S_east_letters = "JKLPQRSTUXYZABCFGHJKLPQR"; // starting from 800000mE
+      const UPS_S_north_letters = "ABCDEFGHJKLMNPQRSTUVWXYZ"; // starting from 800000mN
+      if (ups_obj.northPole) {
+        mgrs_str += UPS_N_east_letters.charAt(Math.floor(ups_obj.easting / 1e5) - 13)
+        mgrs_str += UPS_N_north_letters.charAt(Math.floor(ups_obj.northing / 1e5) - 13)
+      }
+      else {
+        mgrs_str += UPS_S_east_letters.charAt(Math.floor(ups_obj.easting / 1e5) - 8)
+        mgrs_str += UPS_S_north_letters.charAt(Math.floor(ups_obj.northing / 1e5) - 8)
+      }
+      if (precision <= 1) {
+        return mgrs_str;
+      }
+      const MGRS_easting = String(Math.trunc(ups_obj.easting) % 1e5).padStart(5, "0").slice(0, precision - 1);
+      const MGRS_northing = String(Math.trunc(ups_obj.northing) % 1e5).padStart(5, "0").slice(0, precision - 1);
+      mgrs_str += MGRS_easting + MGRS_northing;
+
     } else {
-      var mgrs_str;
+      var mgrs_str = "";
       var usng_str = this.LLtoUSNG(lat, lon, precision);
-  
+
       // remove space delimiters to conform to mgrs spec
       var regexp = / /g;
       mgrs_str = usng_str.replace(regexp, "");
-  
-      return mgrs_str;
+
     }
+    return mgrs_str;
   },
 
   // wrapper function specific to Google Maps, to make a converstion to lat/lng return a GLatLon instance.

--- a/src/usng.ts
+++ b/src/usng.ts
@@ -1386,6 +1386,8 @@ extend(Converter.prototype, {
   //    in MGRS notation.  but the numbers are the same.
   LLtoMGRS: function(lat, lon, precision) {
     if (this.isInUPSSpace(lat)) {
+      var ups_obj = {...this.LLtoUPS(lat, lon), northpole: lat > 0 ? true : false };
+      console.log(ups_obj);
       throw new Error("Not yet Implemented");
     } else {
       var mgrs_str;

--- a/src/usng.ts
+++ b/src/usng.ts
@@ -1385,21 +1385,17 @@ extend(Converter.prototype, {
   //    with no spaces.  space delimiters are optional but allowed in USNG, but are not allowed
   //    in MGRS notation.  but the numbers are the same.
   LLtoMGRS: function(lat, lon, precision) {
-    var mgrs_str;
-    var usng_str = this.LLtoUSNG(lat, lon, precision);
-
-    // remove space delimiters to conform to mgrs spec
-    var regexp = / /g;
-    mgrs_str = usng_str.replace(regexp, "");
-
-    return mgrs_str;
-  },
-
-  LLtoMGRSUPS: function(lat, lon, precision) {
     if (this.isInUPSSpace(lat)) {
-      return this.LLtoUPSString(lat, lon)
+      throw new Error("Not yet Implemented");
     } else {
-      return this.LLtoMGRS(lat, lon, precision)
+      var mgrs_str;
+      var usng_str = this.LLtoUSNG(lat, lon, precision);
+  
+      // remove space delimiters to conform to mgrs spec
+      var regexp = / /g;
+      mgrs_str = usng_str.replace(regexp, "");
+  
+      return mgrs_str;
     }
   },
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "module": "commonjs",
     "target": "es5",
     "declaration": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "lib": [
+	    "es2017",
+	    "dom"
+    ]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Implemented MGRS in polar region as it is defined there too.

Dependency libs changed (soft requirement!):
DOM and es2017 for window in `UsngtoLL` and String.padStart/Math.trunc respectively.

API Change:
`LLtoMGRSUPS` and `LLtoMGRS` have been merged into the later.